### PR TITLE
fix: replace jest with jest-cli as peer

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,11 +63,12 @@
     "cz-conventional-changelog": "^1.1.5",
     "ghooks": "^2.0.2",
     "jest": "^21.2.1",
+    "jest-cli": "^21.0.1",
     "semantic-release": "^6.3.6",
     "typescript": "^2.6.2",
     "validate-commit-msg": "^2.14.0"
   },
   "peerDependencies": {
-    "jest": "^21.0.1"
+    "jest-cli": "^21.0.1"
   }
 }


### PR DESCRIPTION
Seems like `master` and `develop` have diverged with f8e004b1283bd79d1e780d35ac74c5171f291ac1.

Will force-push `master` after fixing the peers in `develop`.