### PR TITLE
feat: update jsdom to 12

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   },
   "dependencies": {
     "jest-zone-patch": "^0.0.7",
-    "jsdom": "^11.3.0",
+    "jsdom": "^12.2.0",
     "ts-jest": "^21.2.3"
   },
   "devDependencies": {


### PR DESCRIPTION
Obvious bug here(calling wrapperForImpl with the wrapper and not the implementation):
https://github.com/jsdom/jsdom/blob/11.12.0/lib/jsdom/living/events/EventTarget-impl.js#L193 
resulting in undefined context of the event handler which leads to error in angular.
Fixed in 12:
https://github.com/jsdom/jsdom/blob/12.2.0/lib/jsdom/living/events/EventTarget-impl.js#L296
